### PR TITLE
Actor::Req/Reply need to implement Send

### DIFF
--- a/projects/01_actor/src/lib.rs
+++ b/projects/01_actor/src/lib.rs
@@ -1,8 +1,8 @@
 use std::{future::Future, marker::PhantomData};
 
 pub trait Actor: Send {
-    type Req;
-    type Reply;
+    type Req: Send;
+    type Reply: Send;
 
     fn handle(&mut self, msg: Self::Req) -> impl Future<Output = Self::Reply> + Send;
 }


### PR DESCRIPTION
Adds `: Send` implementation to Actor::Req and Actor::Reply.

Fixes following compilation error (duplicate error for Actor::Reply):
```
error[E0277]: `<A as Actor>::Req` cannot be sent between threads safely
   --> projects\01_actor\src\lib.rs:23:11
    |
23  |       spawn(async move {
    |  _____-----_^
    | |     |
    | |     required by a bound introduced by this call
24  | |         while let Some((msg, resp_tx)) = rx.recv().await {
25  | |             let resp = actor.handle(msg).await;
26  | |             let _ = resp_tx.send(resp);
27  | |         }
28  | |     });
    | |_____^ `<A as Actor>::Req` cannot be sent between threads safely
    |
    = help: within `(<A as Actor>::Req, tokio::sync::oneshot::Sender<<A as Actor>::Reply>)`, the trait `Send` is not implemented for `<A as Actor>::Req`
    = note: required because it appears within the type `(<A as Actor>::Req, tokio::sync::oneshot::Sender<<A as Actor>::Reply>)`
    = note: required for `Chan<(<A as Actor>::Req, Sender<...>), ...>` to implement `Sync`
    = note: required for `Arc<Chan<(<A as Actor>::Req, Sender<...>), ...>>` to implement `Send`
    ```